### PR TITLE
Bugfix setting value for created_at field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/job_service/model/job.py
+++ b/job_service/model/job.py
@@ -78,7 +78,7 @@ class Job(CamelModel, use_enum_values=True):
     status: JobStatus
     parameters: JobParameters
     log: Optional[List[Log]] = []
-    created_at: str = datetime.now().isoformat()
+    created_at: str
 
     @root_validator(skip_on_failure=True)
     @classmethod

--- a/job_service/model/request.py
+++ b/job_service/model/request.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List, Optional
 
 from pydantic import Extra, root_validator
@@ -66,7 +67,8 @@ class NewJobRequest(CamelModel, extra=Extra.forbid):
         return Job(
             job_id=job_id,
             status='queued',
-            parameters=job_parameters
+            parameters=job_parameters,
+            created_at=datetime.now().isoformat()
         )
 
 

--- a/test/adapter/test_job_db.py
+++ b/test/adapter/test_job_db.py
@@ -26,7 +26,7 @@ JOB = {
     'logs': [
         {'at': datetime.now(), 'message': 'example log'}
     ],
-    'created_at' : '2022-05-18T11:40:22.519222'
+    'created_at': '2022-05-18T11:40:22.519222'
 }
 
 

--- a/test/adapter/test_job_db.py
+++ b/test/adapter/test_job_db.py
@@ -125,6 +125,20 @@ def test_update_job(mocker):
     assert spy.call_count == 3
 
 
+def test_new_job_different_created_at():
+    job1 = NewJobRequest(
+        operation='ADD',
+        target='NEW_DATASET'
+    ).generate_job_from_request("abc")
+
+    job2 = NewJobRequest(
+        operation='ADD',
+        target='NEW_DATASET'
+    ).generate_job_from_request("def")
+
+    assert job1.created_at != job2.created_at
+
+
 def test_update_job_completed(mocker):
     mocker.patch.object(
         job_db, 'in_progress', MockedInProgressCollection()

--- a/test/api/test_job_api.py
+++ b/test/api/test_job_api.py
@@ -18,7 +18,7 @@ JOB_LIST = [
             'target': 'MY_DATASET',
             'operation': 'ADD'
         },
-        created_at ='2022-05-18T11:40:22.519222'
+        created_at='2022-05-18T11:40:22.519222'
     ),
     Job(
         job_id='123-123-123-123',
@@ -27,7 +27,7 @@ JOB_LIST = [
             'target': 'OTHER_DATASET',
             'operation': 'ADD'
         },
-        created_at = '2022-05-18T11:40:22.519222'
+        created_at='2022-05-18T11:40:22.519222'
     )
 ]
 NEW_JOB_REQUEST = {


### PR DESCRIPTION
created_at field value cannot be shared by all instances of Job class, it needs to be initialized for each new Job instance.