### PR TITLE
Update request model

### DIFF
--- a/job_service/app.py
+++ b/job_service/app.py
@@ -4,11 +4,12 @@ import logging
 import json_logging
 
 from flask import Flask
+from pydantic import ValidationError
 
 from job_service.api.job_api import job_api
 from job_service.api.importable_datasets_api import importable_datasets_api
 from job_service.exceptions import (
-    JobExistsException, NotFoundException, BadRequestException
+    JobExistsException, NotFoundException
 )
 from job_service.config.logging import (
     CustomJSONLog, CustomJSONRequestLogFormatter
@@ -43,7 +44,7 @@ def handle_not_found(e):
     return {"message": str(e)}, 404
 
 
-@app.errorhandler(BadRequestException)
+@app.errorhandler(ValidationError)
 def handle_bad_request(e):
     logger.exception(e)
     return {"message": str(e)}, 400

--- a/job_service/exceptions/__init__.py
+++ b/job_service/exceptions/__init__.py
@@ -2,10 +2,6 @@ class NotFoundException(Exception):
     ...
 
 
-class BadRequestException(Exception):
-    ...
-
-
 class JobExistsException(Exception):
     ...
 

--- a/test/model/test_request.py
+++ b/test/model/test_request.py
@@ -1,0 +1,39 @@
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from job_service.model.job import Job, UserInfo
+from job_service.model.request import NewJobsRequest, NewJobRequest
+
+
+RESOURCE_DIR = 'test/resources/model'
+VALID_JOB_REQUESTS_PATH = f'{RESOURCE_DIR}/valid_job_requests.json'
+with open(VALID_JOB_REQUESTS_PATH, 'r', encoding='utf-8') as f:
+    VALID_JOB_REQUESTS = json.load(f)
+INVALID_JOB_REQUESTS_PATH = f'{RESOURCE_DIR}/invalid_job_requests.json'
+with open(INVALID_JOB_REQUESTS_PATH, 'r', encoding='utf-8') as f:
+    INVALID_JOB_REQUESTS = json.load(f)
+JOB_ID = '123-123-123-123'
+USER_INFO_DICT = {
+    'userId': '123-123-123',
+    'firstName': 'Data',
+    'lastName': 'Admin'
+}
+USER_INFO = UserInfo(**USER_INFO_DICT)
+
+
+def test_new_jobs_requests():
+    new_jobs_request = NewJobsRequest(**VALID_JOB_REQUESTS)
+    for job_request in new_jobs_request.jobs:
+        assert job_request.target is not None
+        assert job_request.operation is not None
+        assert isinstance(
+            job_request.generate_job_from_request(JOB_ID, USER_INFO), Job
+        )
+
+
+def test_invalid_new_jobs_requests():
+    for job in INVALID_JOB_REQUESTS['jobs']:
+        with pytest.raises(ValidationError):
+            NewJobRequest(**job)

--- a/test/resources/model/invalid_job_requests.json
+++ b/test/resources/model/invalid_job_requests.json
@@ -1,0 +1,64 @@
+{
+    "jobs": [
+        {
+            "operation": "ADD"
+        },
+        {
+            "operation": "SET_STATUS",
+            "target": "MY_DATASET"
+        },
+        {
+            "operation": "REMOVE",
+            "target": "MY_DATASET"
+        },
+        {
+            "operation": "BUMP",
+            "target": "DATASTORE",
+            "description": "Bump datastore version",
+            "bumpToVersion": "1.1.0",
+            "bumpManifesto": {
+                "version": "0.0.0.1634512323",
+                "description": "Draft",
+                "releaseTime": 1634512323,
+                "languageCode": "no",
+                "updateType": "MINOR",
+                "dataStructureUpdates": [
+                    {
+                        "name": "MY_DATASET",
+                        "description": "Første publisering",
+                        "operation": "ADD",
+                        "releaseStatus": "PENDING_RELEASE"
+                    }                   
+                ]
+            }
+        },
+        {
+            "operation": "BUMP",
+            "target": "DATASTORE",
+            "description": "Bump datastore version",
+            "bumpFromVersion": "1.0.0",
+            "bumpToVersion": "1.1.0"
+        },
+        {
+            "operation": "BUMP",
+            "target": "OTHER",
+            "description": "Bump datastore version",
+            "bumpToVersion": "1.1.0",
+            "bumpManifesto": {
+                "version": "0.0.0.1634512323",
+                "description": "Draft",
+                "releaseTime": 1634512323,
+                "languageCode": "no",
+                "updateType": "MINOR",
+                "dataStructureUpdates": [
+                    {
+                        "name": "MY_DATASET",
+                        "description": "Første publisering",
+                        "operation": "ADD",
+                        "releaseStatus": "PENDING_RELEASE"
+                    }                   
+                ]
+            }
+        }
+    ]
+}

--- a/test/resources/model/valid_job_requests.json
+++ b/test/resources/model/valid_job_requests.json
@@ -1,0 +1,40 @@
+{
+    "jobs": [
+        {
+            "operation": "ADD",
+            "target": "MY_DATASET"
+        },
+        {
+            "operation": "SET_STATUS",
+            "target": "MY_DATASET",
+            "releaseStatus": "PENDING_RELEASE"
+        },
+        {
+            "operation": "REMOVE",
+            "target": "MY_DATASET",
+            "description": "Removed my dataset from datastore"
+        },
+        {
+            "operation": "BUMP",
+            "target": "DATASTORE",
+            "description": "Bump datastore version",
+            "bumpFromVersion": "1.0.0",
+            "bumpToVersion": "1.1.0",
+            "bumpManifesto": {
+                "version": "0.0.0.1634512323",
+                "description": "Draft",
+                "releaseTime": 1634512323,
+                "languageCode": "no",
+                "updateType": "MINOR",
+                "dataStructureUpdates": [
+                    {
+                        "name": "MY_DATASET",
+                        "description": "Første publisering",
+                        "operation": "ADD",
+                        "releaseStatus": "PENDING_RELEASE"
+                    }                   
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
# UPDATE REQUEST MODEL

Update to the request models, in order to be able to request jobs with the updates to the job model.
Added tests to request models to reflect this case, and cleaned up one unnecessary exception.

### Next
Update the requests for bumps in the frontend as these now have new fields. The added user_id fields do not effect the request models as it is handled by the job-service itself using the JWT header (temporarily injected).