### PR TITLE
Return job ID when creating new jobs

### DIFF
--- a/job_service/api/job_api.py
+++ b/job_service/api/job_api.py
@@ -35,8 +35,12 @@ def new_job(body: NewJobsRequest):
     )
     for job in body.jobs:
         try:
-            job_db.new_job(job, user_info)
-            response_list.append({'status': 'queued', 'msg': 'CREATED'})
+            job_id = job_db.new_job(job, user_info)
+            response_list.append({
+                'status': 'queued',
+                'msg': 'CREATED',
+                'job_id': job_id
+            })
         except Exception:
             response_list.append({'status': 'FAILED', 'msg': 'FAILED'})
     return jsonify(response_list), 200

--- a/test/api/test_job_api.py
+++ b/test/api/test_job_api.py
@@ -108,8 +108,8 @@ def test_new_job(flask_app, mocker):
     )
     assert response.status_code == 200
     assert response.json == [
-        {'msg': 'CREATED', 'status': 'queued'},
-        {'msg': 'CREATED', 'status': 'queued'}
+        {'msg': 'CREATED', 'status': 'queued', 'job_id': JOB_ID},
+        {'msg': 'CREATED', 'status': 'queued', 'job_id': JOB_ID}
     ]
 
 


### PR DESCRIPTION
Will be used to know the status of the "commit changes" jobs on the Datastore page.