### PR TITLE
Targets collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ _____
 >
 >  | status | json                                                                                        |
 >  |--------|---------------------------------------------------------------------------------------------|
->  |   200  |```[{"status": "CREATED", "msg": "OK"}, {"status": "FAILED", "msg": "Missing operation"}]``` |
+>  |   200  |```[{"job_id": "123-123-123", status": "CREATED", "msg": "OK"}, {"status": "FAILED", "msg": "Missing operation"}]``` |
 >  |   400  |```{"message": "<Error message>"}```                                                         |
 >  |   500  |```{"message": "<Error message>"}```                                                         |
 >
@@ -109,6 +109,46 @@ _____
 >  |   500  |```{"message": "<Error message>"}```                                               |
 >
 ></details>
+_____
+> ### **[GET]** `/targets`
+>Get all target objects
+><details>
+>  <summary>Example request</summary>
+>  
+>  ```curl -X GET <url>/targets```
+></details>
+></details>
+><details>
+>  <summary>Responses</summary>
+>
+>  | status | json                                                                                        |
+>  |--------|---------------------------------------------------------------------------------------------|
+>  |   200  |```[...targets]``` |
+>  |   400  |```{"message": "<Error message>"}```                                                         |
+>  |   500  |```{"message": "<Error message>"}```                                                         |
+>
+></details>
+_____
+> ### **[GET]** `/targets/<name>`
+>Get all jobs for target with given name, or datastore bump jobs containing the target name
+> in its datastore updates.
+><details>
+>  <summary>Example request</summary>
+>  
+>  ```curl -X GET <url>/targets/<name>```
+></details>
+></details>
+><details>
+>  <summary>Responses</summary>
+>
+>  | status | json                                                                                        |
+>  |--------|---------------------------------------------------------------------------------------------|
+>  |   200  |```[...jobs]``` |
+>  |   400  |```{"message": "<Error message>"}```                                                         |
+>  |   500  |```{"message": "<Error message>"}```                                                         |
+>
+></details>
+_____
 </br>
 </br>
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ _____
 ><details>
 >  <summary>Example request</summary>
 >  
->  ```curl -X GET <url>/targets/<name>```
+>  ```curl -X GET <url>/targets/<name>/jobs```
 ></details>
 ></details>
 ><details>

--- a/job_service/adapter/job_db.py
+++ b/job_service/adapter/job_db.py
@@ -107,7 +107,7 @@ def new_job(new_job_request: NewJobRequest, user_info: UserInfo) -> Job:
     return job
 
 
-def update_job(job_id: str, body: UpdateJobRequest) -> str:
+def update_job(job_id: str, body: UpdateJobRequest) -> Job:
     """
     Updates job with supplied job_id with new status.
     Appends additional log if supplied.

--- a/job_service/adapter/job_db.py
+++ b/job_service/adapter/job_db.py
@@ -59,7 +59,24 @@ def get_jobs(query: GetJobRequest) -> List[Job]:
     return [Job(**job) for job in jobs if job is not None]
 
 
-def new_job(new_job_request: NewJobRequest, user_info: UserInfo) -> str:
+def get_jobs_for_target(name: str) -> List[Job]:
+    """
+    Returns list of jobs with matching target name for database.
+    Including datastore bump jobs that include the name in
+    datastructureUpdates.
+    """
+    find_query = {
+        '$or': [
+            {'parameters.bumpManifesto.dataStructureUpdates.name': name},
+            {'parameters.target': name}
+        ]
+    }
+    in_progress_jobs = list(in_progress.find(find_query))
+    completed_jobs = list(completed.find(find_query))
+    return [Job(**job) for job in in_progress_jobs + completed_jobs]
+
+
+def new_job(new_job_request: NewJobRequest, user_info: UserInfo) -> Job:
     """
     Creates a new job for supplied command, status and dataset_name, and
     returns job_id of created job.
@@ -68,10 +85,10 @@ def new_job(new_job_request: NewJobRequest, user_info: UserInfo) -> str:
     job_id = str(uuid.uuid4())
     job = new_job_request.generate_job_from_request(job_id, user_info)
     update_result = None
-    logger.info(f'inserting new job {job}')
+    logger.info(f'Inserting new job {job}')
     try:
         update_result: UpdateResult = in_progress.update_one(
-            {"target": job.parameters.target},
+            {"parameters.target": job.parameters.target},
             {"$setOnInsert": job.dict(by_alias=True)},
             upsert=True
         )
@@ -87,27 +104,24 @@ def new_job(new_job_request: NewJobRequest, user_info: UserInfo) -> str:
             f'Job with target {job.target} already in progress'
         )
     logger.info(f'Successfully inserted new job: {job}')
-    return job_id
+    return job
 
 
-def update_job(job_id: str, body: UpdateJobRequest) -> None:
+def update_job(job_id: str, body: UpdateJobRequest) -> str:
     """
     Updates job with supplied job_id with new status.
     Appends additional log if supplied.
     """
     now = datetime.now()
     find_query = {"jobId": job_id}
-    job = in_progress.find_one(find_query)
+    job: Job = in_progress.find_one(find_query)
     if job is None:
         raise NotFoundException(f"Could not find job with id {job_id}")
 
     update_query = {
         "$set": {},
         "$push": {
-            "log": {
-                "at": now,
-                "message": ""
-            }
+            "log": {"at": now, "message": ""}
         }
     }
     if body.status is not None:
@@ -131,7 +145,9 @@ def update_job(job_id: str, body: UpdateJobRequest) -> None:
         completed.update_one(find_query, update_query)
         if body.log is not None:
             completed.update_one(find_query, log_update_query)
+        return Job(**completed.find_one(find_query))
     else:
         in_progress.update_one(find_query, update_query)
         if body.log is not None:
             in_progress.update_one(find_query, log_update_query)
+        return Job(**in_progress.find_one(find_query))

--- a/job_service/adapter/target_db.py
+++ b/job_service/adapter/target_db.py
@@ -1,0 +1,53 @@
+import logging
+from typing import List
+from datetime import datetime
+
+import pymongo
+
+from job_service.config import environment, secrets
+from job_service.model.job import Job
+from job_service.model.target import Target
+
+
+MONGODB_URL = environment.get('MONGODB_URL')
+MONGODB_USER = secrets.get('MONGODB_USER')
+MONGODB_PASSWORD = secrets.get('MONGODB_PASSWORD')
+
+client = pymongo.MongoClient(
+    MONGODB_URL,
+    username=MONGODB_USER,
+    password=MONGODB_PASSWORD,
+    authSource='admin'
+)
+db = client.jobDB
+targets_collection = db.targets
+
+logger = logging.getLogger()
+
+
+def get_targets() -> List[Target]:
+    """
+    Returns list of all targets present in the targets database collection.
+    """
+    targets = targets_collection.find({}, {'_id': 0})
+    return [Target(**target) for target in targets if target is not None]
+
+
+def update_target(job: Job) -> None:
+    """
+    Updates a target with the supplied job state. If no such
+    target exists in the collection, a new target is created
+    from the supplied job state.
+    """
+    targets_collection.update_one(
+        {'name': job.parameters.target},
+        {
+            '$set': {
+                'lastUpdatedAt': datetime.now().isoformat(),
+                'status': job.status,
+                'lastUpdatedBy': job.created_by.dict(by_alias=True),
+                'action': job.get_action()
+            }
+        },
+        upsert=True
+    )

--- a/job_service/api/job_api.py
+++ b/job_service/api/job_api.py
@@ -64,4 +64,6 @@ def update_job(body: UpdateJobRequest, job_id: str):
     )
     job = job_db.update_job(job_id, body)
     target_db.update_target(job)
+    if job.parameters.target == "DATASTORE" and job.status == "completed":
+        target_db.update_bump_targets(job)
     return {'message': f'Updated job with jobId {job_id}'}

--- a/job_service/api/targets_api.py
+++ b/job_service/api/targets_api.py
@@ -18,9 +18,9 @@ def get_targets():
     return jsonify([target.dict(by_alias=True) for target in targets])
 
 
-@targets_api.route('/targets/<name>', methods=['GET'])
+@targets_api.route('/targets/<name>/jobs', methods=['GET'])
 @validate()
-def get_target(name: str):
+def get_target_jobs(name: str):
     logger.info(f'GET /targets/{name}')
     jobs = job_db.get_jobs_for_target(name)
     return [job.dict(by_alias=True) for job in jobs]

--- a/job_service/api/targets_api.py
+++ b/job_service/api/targets_api.py
@@ -1,0 +1,26 @@
+import logging
+
+from flask import Blueprint, jsonify
+from flask_pydantic import validate
+
+from job_service.adapter import target_db
+
+
+logger = logging.getLogger()
+targets_api = Blueprint('targets_api', __name__)
+
+
+@targets_api.route('/targets', methods=['GET'])
+@validate()
+def get_targets():
+    logger.debug('GET /targets')
+    targets = target_db.get_targets()
+    return jsonify([target.dict(by_alias=True) for target in targets])
+
+
+@targets_api.route('/targets/<name>', methods=['GET'])
+@validate()
+def get_target(name: str):
+    logger.info(f'GET /jobs/{name}')
+    target = target_db.get_target(name)
+    return target.dict(by_alias=True)

--- a/job_service/api/targets_api.py
+++ b/job_service/api/targets_api.py
@@ -3,7 +3,7 @@ import logging
 from flask import Blueprint, jsonify
 from flask_pydantic import validate
 
-from job_service.adapter import target_db
+from job_service.adapter import target_db, job_db
 
 
 logger = logging.getLogger()
@@ -21,6 +21,6 @@ def get_targets():
 @targets_api.route('/targets/<name>', methods=['GET'])
 @validate()
 def get_target(name: str):
-    logger.info(f'GET /jobs/{name}')
-    target = target_db.get_target(name)
-    return target.dict(by_alias=True)
+    logger.info(f'GET /targets/{name}')
+    jobs = job_db.get_jobs_for_target(name)
+    return [job.dict(by_alias=True) for job in jobs]

--- a/job_service/app.py
+++ b/job_service/app.py
@@ -7,6 +7,7 @@ from flask import Flask
 from pydantic import ValidationError
 
 from job_service.api.job_api import job_api
+from job_service.api.targets_api import targets_api
 from job_service.api.importable_datasets_api import importable_datasets_api
 from job_service.exceptions import (
     JobExistsException, NotFoundException
@@ -34,6 +35,7 @@ logger.addHandler(logging.StreamHandler(sys.stdout))
 app = Flask(__name__)
 app.register_blueprint(job_api)
 app.register_blueprint(importable_datasets_api)
+app.register_blueprint(targets_api)
 
 init_json_logging()
 

--- a/job_service/model/job.py
+++ b/job_service/model/job.py
@@ -101,3 +101,19 @@ class Job(CamelModel, use_enum_values=True):
                 'message': 'Job generated and queued'
             }]
         return values
+
+    def get_action(self) -> list[str]:
+        match(self.parameters.operation):
+            case 'SET_STATUS':
+                return [
+                    self.parameters.operation,
+                    self.parameters.release_status
+                ]
+            case 'BUMP':
+                return [
+                    self.parameters.operation,
+                    self.parameters.bump_from_version,
+                    self.parameters.bump_to_version
+                ]
+            case _:
+                return [self.parameters.operation]

--- a/job_service/model/target.py
+++ b/job_service/model/target.py
@@ -1,0 +1,20 @@
+from typing import List
+
+from pydantic import Extra
+
+from job_service.model.enums import JobStatus
+from job_service.model.camelcase_model import CamelModel
+
+
+class UserInfo(CamelModel, extra=Extra.forbid):
+    user_id: str
+    first_name: str
+    last_name: str
+
+
+class Target(CamelModel, use_enum_values=True):
+    name: str
+    jobs: List[str]
+    last_update: str
+    last_updated_by: UserInfo
+    last_status: JobStatus

--- a/job_service/model/target.py
+++ b/job_service/model/target.py
@@ -1,20 +1,14 @@
 from typing import List
-
 from pydantic import Extra
 
-from job_service.model.enums import JobStatus
 from job_service.model.camelcase_model import CamelModel
+from job_service.model.enums import JobStatus
+from job_service.model.job import UserInfo
 
 
-class UserInfo(CamelModel, extra=Extra.forbid):
-    user_id: str
-    first_name: str
-    last_name: str
-
-
-class Target(CamelModel, use_enum_values=True):
+class Target(CamelModel, use_enum_values=True, extra=Extra.forbid):
     name: str
-    jobs: List[str]
-    last_update: str
+    last_updated_at: str
+    status: JobStatus
     last_updated_by: UserInfo
-    last_status: JobStatus
+    action: List[str]

--- a/test/adapter/test_job_db.py
+++ b/test/adapter/test_job_db.py
@@ -36,7 +36,7 @@ JOB = {
 }
 
 
-mongo = MongoDbContainer("mongo:5")
+mongo = MongoDbContainer("mongo:5.0")
 mongo.start()
 DB_CLIENT = mongo.get_connection_client()
 

--- a/test/adapter/test_job_db.py
+++ b/test/adapter/test_job_db.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 
 import pytest
+from pytest_mock import MockFixture
 from testcontainers.mongodb import MongoDbContainer
 
 from job_service.adapter import job_db
@@ -36,21 +37,15 @@ JOB = {
 
 
 mongo = MongoDbContainer("mongo:5")
-DB_CLIENT = None
-
-
-def setup_module():
-    # pylint: disable=global-statement
-    global DB_CLIENT
-    mongo.start()
-    DB_CLIENT = mongo.get_connection_client()
+mongo.start()
+DB_CLIENT = mongo.get_connection_client()
 
 
 def teardown_module():
     mongo.stop()
 
 
-def test_get_job(mocker):
+def test_get_job(mocker: MockFixture):
     DB_CLIENT.jobdb.drop_collection('in_progress')
     DB_CLIENT.jobdb.drop_collection('completed')
     DB_CLIENT.jobdb.in_progress.insert_one(JOB)
@@ -72,7 +67,7 @@ def test_get_job(mocker):
     assert "No job found for jobId:" in str(e)
 
 
-def test_get_jobs(mocker):
+def test_get_jobs(mocker: MockFixture):
     DB_CLIENT.jobdb.drop_collection('in_progress')
     DB_CLIENT.jobdb.drop_collection('completed')
     DB_CLIENT.jobdb.in_progress.insert_one(JOB)
@@ -91,7 +86,7 @@ def test_get_jobs(mocker):
     assert job_db.get_jobs(get_job_request) == [Job(**JOB)]
 
 
-def test_new_job(mocker):
+def test_new_job(mocker: MockFixture):
     DB_CLIENT.jobdb.drop_collection('in_progress')
     DB_CLIENT.jobdb.drop_collection('completed')
     mocker.patch.object(
@@ -117,7 +112,7 @@ def test_new_job(mocker):
     assert actual.parameters.operation == 'ADD'
 
 
-def test_update_job(mocker):
+def test_update_job(mocker: MockFixture):
     DB_CLIENT.jobdb.drop_collection('in_progress')
     DB_CLIENT.jobdb.drop_collection('completed')
     DB_CLIENT.jobdb.in_progress.insert_one(JOB)
@@ -161,7 +156,7 @@ def test_new_job_different_created_at():
     assert job1.created_at != job2.created_at
 
 
-def test_update_job_completed(mocker):
+def test_update_job_completed(mocker: MockFixture):
     DB_CLIENT.jobdb.drop_collection('in_progress')
     DB_CLIENT.jobdb.drop_collection('completed')
     DB_CLIENT.jobdb.in_progress.insert_one(JOB)
@@ -184,7 +179,7 @@ def test_update_job_completed(mocker):
     assert DB_CLIENT.jobdb.completed.count_documents({}) == 1
 
 
-def test_update_job_failed(mocker):
+def test_update_job_failed(mocker: MockFixture):
     DB_CLIENT.jobdb.drop_collection('in_progress')
     DB_CLIENT.jobdb.drop_collection('completed')
     DB_CLIENT.jobdb.in_progress.insert_one(JOB)

--- a/test/adapter/test_target_db.py
+++ b/test/adapter/test_target_db.py
@@ -1,9 +1,12 @@
 # pylint: disable=unused-argument
+from pytest_mock import MockFixture
 from testcontainers.mongodb import MongoDbContainer
 
 from job_service.adapter import target_db
-from job_service.model.job import Job
 from job_service.model.target import Target
+from job_service.model.job import (
+    DataStructureUpdate, DatastoreVersion, Job, JobParameters
+)
 
 
 USER_INFO_DICT = {
@@ -47,24 +50,64 @@ NEW_TARGET_JOB = Job(
     created_at='2022-05-18T11:40:22.519222',
     created_by=USER_INFO_DICT
 )
+BUMP_JOB = Job(
+    job_id='bump-bump-bump-bump',
+    status='completed',
+    created_at='2022-05-18T11:40:22.519222',
+    created_by=USER_INFO_DICT,
+    parameters=JobParameters(
+        bump_from_version='1.0.0',
+        bump_to_version='1.1.0',
+        operation='BUMP',
+        target='DATASTORE',
+        description='Updates',
+        bumpManifesto=DatastoreVersion(
+            version='0.0.0.123123',
+            description='Draft version',
+            release_time='123123',
+            language_code='no',
+            update_type='MINOR',
+            data_structure_updates=[
+                DataStructureUpdate(
+                    name='MY_DATASET',
+                    description='Update',
+                    operation='PATCH_METADATA',
+                    release_status='PENDING_RELEASE'
+                ),
+                DataStructureUpdate(
+                    name='FRESH_DATASET',
+                    description='Update',
+                    operation='ADD',
+                    release_status='PENDING_RELEASE'
+                ),
+                DataStructureUpdate(
+                    name='FRESH_DATASET2',
+                    description='Update',
+                    operation='ADD',
+                    release_status='PENDING_RELEASE'
+                ),
+                DataStructureUpdate(
+                    name='NOT_BUMPED_DATASET',
+                    description='Update',
+                    operation='ADD',
+                    release_status='DRAFT'
+                )
+            ]
+        )
+    )
+)
 
 
 mongo = MongoDbContainer("mongo:5")
-DB_CLIENT = None
-
-
-def setup_module():
-    # pylint: disable=global-statement
-    global DB_CLIENT
-    mongo.start()
-    DB_CLIENT = mongo.get_connection_client()
+mongo.start()
+DB_CLIENT = mongo.get_connection_client()
 
 
 def teardown_module():
     mongo.stop()
 
 
-def test_get_targets(mocker):
+def test_get_targets(mocker: MockFixture):
     DB_CLIENT.jobdb.drop_collection('targets')
     DB_CLIENT.jobdb.targets.insert_one(TARGET_LIST[0].dict(by_alias=True))
     assert DB_CLIENT.jobdb.targets.count_documents({}) == 1
@@ -76,7 +119,7 @@ def test_get_targets(mocker):
     assert target_db.get_targets() == [TARGET_LIST[0]]
 
 
-def test_update_target(mocker):
+def test_update_target(mocker: MockFixture):
     DB_CLIENT.jobdb.drop_collection('targets')
     DB_CLIENT.jobdb.targets.insert_one(TARGET_LIST[0].dict(by_alias=True))
     assert DB_CLIENT.jobdb.targets.count_documents({}) == 1
@@ -99,3 +142,26 @@ def test_update_target(mocker):
         None
     )
     assert updated_target.action == ['ADD']
+
+
+def test_update_targets_bump(mocker: MockFixture):
+    DB_CLIENT.jobdb.drop_collection('targets')
+    DB_CLIENT.jobdb.targets.insert_one(TARGET_LIST[0].dict(by_alias=True))
+    assert DB_CLIENT.jobdb.targets.count_documents({}) == 1
+
+    mocker.patch.object(
+        target_db, 'targets_collection',
+        DB_CLIENT.jobdb.targets
+    )
+
+    target_db.update_bump_targets(BUMP_JOB)
+    assert DB_CLIENT.jobdb.targets.count_documents({}) == 3
+    targets = target_db.get_targets()
+    assert len(targets) == 3
+    assert [target.action[0] for target in targets] == [
+        'RELEASED', 'RELEASED', 'RELEASED'
+    ]
+    target_names = [target.name for target in targets]
+    assert 'MY_DATASET' in target_names
+    assert 'FRESH_DATASET' in target_names
+    assert 'FRESH_DATASET2' in target_names

--- a/test/adapter/test_target_db.py
+++ b/test/adapter/test_target_db.py
@@ -1,0 +1,101 @@
+# pylint: disable=unused-argument
+from testcontainers.mongodb import MongoDbContainer
+
+from job_service.adapter import target_db
+from job_service.model.job import Job
+from job_service.model.target import Target
+
+
+USER_INFO_DICT = {
+    'userId': '123-123-123',
+    'firstName': 'Data',
+    'lastName': 'Admin'
+}
+TARGET_LIST = [
+    Target(
+        name="MY_DATASET",
+        last_updated_at='2022-05-18T11:40:22.519222',
+        status='completed',
+        action=['SET_STATUS', 'PENDING_RELEASE'],
+        last_updated_by=USER_INFO_DICT
+    ),
+    Target(
+        name="OTHER_DATASET",
+        last_updated_at='2022-05-18T11:40:22.519222',
+        status='completed',
+        action=['SET_STATUS', 'PENDING_RELEASE'],
+        last_updated_by=USER_INFO_DICT
+    )
+]
+TARGET_UPDATE_JOB = Job(
+    job_id='123-123-123-123',
+    status='queued',
+    parameters={
+        'target': 'MY_DATASET',
+        'operation': 'ADD'
+    },
+    created_at='2022-05-18T11:40:22.519222',
+    created_by=USER_INFO_DICT
+)
+NEW_TARGET_JOB = Job(
+    job_id='123-123-123-123',
+    status='queued',
+    parameters={
+        'target': 'NEW_DATASET',
+        'operation': 'ADD'
+    },
+    created_at='2022-05-18T11:40:22.519222',
+    created_by=USER_INFO_DICT
+)
+
+
+mongo = MongoDbContainer("mongo:5")
+DB_CLIENT = None
+
+
+def setup_module():
+    # pylint: disable=global-statement
+    global DB_CLIENT
+    mongo.start()
+    DB_CLIENT = mongo.get_connection_client()
+
+
+def teardown_module():
+    mongo.stop()
+
+
+def test_get_targets(mocker):
+    DB_CLIENT.jobdb.drop_collection('targets')
+    DB_CLIENT.jobdb.targets.insert_one(TARGET_LIST[0].dict(by_alias=True))
+    assert DB_CLIENT.jobdb.targets.count_documents({}) == 1
+
+    mocker.patch.object(
+        target_db, 'targets_collection',
+        DB_CLIENT.jobdb.targets
+    )
+    assert target_db.get_targets() == [TARGET_LIST[0]]
+
+
+def test_update_target(mocker):
+    DB_CLIENT.jobdb.drop_collection('targets')
+    DB_CLIENT.jobdb.targets.insert_one(TARGET_LIST[0].dict(by_alias=True))
+    assert DB_CLIENT.jobdb.targets.count_documents({}) == 1
+
+    mocker.patch.object(
+        target_db, 'targets_collection',
+        DB_CLIENT.jobdb.targets
+    )
+    target_db.update_target(TARGET_UPDATE_JOB)
+    assert DB_CLIENT.jobdb.targets.count_documents({}) == 1
+    updated_target = target_db.get_targets()[0]
+    assert updated_target.action == ['ADD']
+    assert updated_target.status == 'queued'
+
+    target_db.update_target(NEW_TARGET_JOB)
+    assert DB_CLIENT.jobdb.targets.count_documents({}) == 2
+    targets = target_db.get_targets()
+    updated_target = next(
+        (target for target in targets if target.name == 'NEW_DATASET'),
+        None
+    )
+    assert updated_target.action == ['ADD']

--- a/test/adapter/test_target_db.py
+++ b/test/adapter/test_target_db.py
@@ -98,7 +98,7 @@ BUMP_JOB = Job(
 )
 
 
-mongo = MongoDbContainer("mongo:5")
+mongo = MongoDbContainer("mongo:5.0")
 mongo.start()
 DB_CLIENT = mongo.get_connection_client()
 

--- a/test/api/test_targets_api.py
+++ b/test/api/test_targets_api.py
@@ -79,7 +79,7 @@ def test_get_target(flask_app, mocker):
         job_db, 'get_jobs_for_target', return_value=JOB_LIST
     )
     response = flask_app.get(
-        url_for('targets_api.get_target', name='MY_DATASET')
+        url_for('targets_api.get_target_jobs', name='MY_DATASET')
     )
     get_jobs_for_target.assert_called_once()
     get_jobs_for_target.assert_called_with('MY_DATASET')
@@ -92,7 +92,7 @@ def test_get_target_none_found(flask_app, mocker):
         job_db, 'get_jobs_for_target', return_value=[]
     )
     response = flask_app.get(
-        url_for('targets_api.get_target', name='MY_DATASET')
+        url_for('targets_api.get_target_jobs', name='MY_DATASET')
     )
     get_job.assert_called_once()
     get_job.assert_called_with('MY_DATASET')

--- a/test/api/test_targets_api.py
+++ b/test/api/test_targets_api.py
@@ -1,0 +1,100 @@
+from flask import url_for
+
+from job_service.adapter import job_db, target_db
+from job_service.model.job import Job, UserInfo
+from job_service.model.target import Target
+
+
+JOB_ID = '123-123-123-123'
+USER_INFO_DICT = {
+    'userId': '123-123-123',
+    'firstName': 'Data',
+    'lastName': 'Admin'
+}
+USER_INFO = UserInfo(**USER_INFO_DICT)
+TARGET_LIST = [
+    Target(
+        name="MY_DATASET",
+        last_updated_at='2022-05-18T11:40:22.519222',
+        status='completed',
+        action=['ADD'],
+        last_updated_by=USER_INFO_DICT
+    ),
+    Target(
+        name="OTHER_DATASET",
+        last_updated_at='2022-05-18T11:40:22.519222',
+        status='completed',
+        action=['SET_STATUS', 'PENDING_RELEASE'],
+        last_updated_by=USER_INFO_DICT
+    )
+]
+JOB_LIST = [
+    Job(
+        job_id='123-123-123-123',
+        status='completed',
+        parameters={
+            'target': 'MY_DATASET',
+            'operation': 'ADD'
+        },
+        created_at='2022-05-18T11:40:22.519222',
+        created_by=USER_INFO_DICT
+    ),
+    Job(
+        job_id='123-123-123-123',
+        status='completed',
+        parameters={
+            'target': 'OTHER_DATASET',
+            'operation': 'ADD'
+        },
+        created_at='2022-05-18T11:40:22.519222',
+        created_by=USER_INFO_DICT
+    )
+]
+
+
+def test_get_targets(flask_app, mocker):
+    get_jobs = mocker.patch.object(
+        target_db, 'get_targets', return_value=TARGET_LIST
+    )
+    response = flask_app.get(url_for("targets_api.get_targets"))
+    assert response.json == [
+        target.dict(by_alias=True) for target in TARGET_LIST
+    ]
+    assert response.status_code == 200
+    get_jobs.assert_called_once()
+
+
+def test_get_targets_none_found(flask_app, mocker):
+    get_jobs = mocker.patch.object(
+        target_db, 'get_targets', return_value=[]
+    )
+    response = flask_app.get(url_for("targets_api.get_targets"))
+    assert response.json == []
+    assert response.status_code == 200
+    get_jobs.assert_called_once()
+
+
+def test_get_target(flask_app, mocker):
+    get_jobs_for_target = mocker.patch.object(
+        job_db, 'get_jobs_for_target', return_value=JOB_LIST
+    )
+    response = flask_app.get(
+        url_for('targets_api.get_target', name='MY_DATASET')
+    )
+    get_jobs_for_target.assert_called_once()
+    get_jobs_for_target.assert_called_with('MY_DATASET')
+    assert response.status_code == 200
+    assert response.json == [job.dict(by_alias=True) for job in JOB_LIST]
+
+
+def test_get_target_none_found(flask_app, mocker):
+    get_job = mocker.patch.object(
+        job_db, 'get_jobs_for_target', return_value=[]
+    )
+    response = flask_app.get(
+        url_for('targets_api.get_target', name='MY_DATASET')
+    )
+    get_job.assert_called_once()
+    get_job.assert_called_with('MY_DATASET')
+    assert response.status_code == 200
+    assert response.json == []


### PR DESCRIPTION
# TARGETS COLLECTION

New convenience collection for storing the latest state of a given job target.

### What's changed?
* New target collection with associated adapter "target_db.py"
* All new posted jobs, and job updates now updates the state of the target collection on write
* Bump jobs updates the state of all targets included in dataStructureUpdates
* /targets/<name> queries the job collection for all jobs  that parameters.target = name or all bump jobs that references that <name> in its dataStructureUpdates