### PR TITLE
User info implementation

### DIFF
--- a/job_service/api/job_api.py
+++ b/job_service/api/job_api.py
@@ -4,7 +4,6 @@ from flask import Blueprint, jsonify
 from flask_pydantic import validate
 
 from job_service.adapter import job_db, target_db
-from job_service.model.job import UserInfo
 from job_service.model.request import (
     NewJobsRequest, UpdateJobRequest, GetJobRequest
 )
@@ -28,14 +27,9 @@ def get_jobs(query: GetJobRequest):
 def new_job(body: NewJobsRequest):
     logger.info(f'POST /jobs with request body: {body}')
     response_list = []
-    user_info = UserInfo(
-        userId='123-123-123',
-        firstName='Data',
-        lastName='Admin'
-    )
     for job_request in body.jobs:
         try:
-            job = job_db.new_job(job_request, user_info)
+            job = job_db.new_job(job_request, body.user_info)
             response_list.append({
                 'status': 'queued',
                 'msg': 'CREATED',

--- a/job_service/model/request.py
+++ b/job_service/model/request.py
@@ -86,6 +86,7 @@ class NewJobRequest(CamelModel, extra=Extra.forbid):
 
 
 class NewJobsRequest(CamelModel, extra=Extra.forbid):
+    user_info: UserInfo
     jobs: List[NewJobRequest]
 
 

--- a/test/api/test_job_api.py
+++ b/test/api/test_job_api.py
@@ -39,6 +39,7 @@ JOB_LIST = [
     )
 ]
 NEW_JOB_REQUEST = {
+    'userInfo': USER_INFO.dict(),
     'jobs': [
         {'operation': 'ADD', 'target': 'MY_DATASET'},
         {'operation': 'CHANGE', 'target': 'OTHER_DATASET'}

--- a/test/resources/model/valid_job_requests.json
+++ b/test/resources/model/valid_job_requests.json
@@ -1,4 +1,9 @@
 {
+    "userInfo": {
+        "userId": "123-123-123",
+        "firstName": "Data",
+        "lastName": "Admin"
+    },
     "jobs": [
         {
             "operation": "ADD",


### PR DESCRIPTION
# PROPER IMPLEMENTATION OF USER INFO

Gets the user info from the request body. Since this has already been implemented properly in all layers except for the API layer it requires almost no changes.

### What's new?
* Removed injection of a placeholder userinfo object into the api layer
* Updated the request model and tests

### Notes
Is it better to just forward the cookies themselves and decode the jwt in job-service to get the user credentials? And if so; is this an acceptable first implementation?