### PR TITLE
Disabled flask-logger.

### DIFF
--- a/job_service/app.py
+++ b/job_service/app.py
@@ -29,6 +29,9 @@ def init_json_logging():
 
 
 logger = logging.getLogger()
+
+logging.getLogger('flask-request-logger').disabled = True
+
 logger.setLevel(logging.INFO)
 logger.addHandler(logging.StreamHandler(sys.stdout))
 


### PR DESCRIPTION
I have testet that `flask-request-logger` is now gone, but root logging still works.

`curl http://localhost:10030/importable-datasets` gives this log entry:

```
{
  "@timestamp": "2023-05-05T11:01:01.575Z",
  "command": "[\"/usr/local/bin/gunicorn\", \"job_service.app:app\", \"--bind\", \"0.0.0.0:8000\", \"--workers\", \"1\"]",
  "error.stack": null,
  "host": "localhost",
  "message": "GET /importable-datasets",
  "level": 20,
  "levelName": "INFO",
  "loggerName": "root",
  "method": null,
  "responseTime": null,
  "schemaVersion": "v3",
  "serviceName": "job-service",
  "serviceVersion": "0.1.0",
  "source_host": null,
  "statusCode": null,
  "thread": "MainThread",
  "url": null,
  "xRequestId": "job-service-1f62f894-eb34-11ed-9bef-0242ac160006"
}
```

I think this should do.