### PR TITLE
Use userinfo token

### DIFF
--- a/job_service/api/auth.py
+++ b/job_service/api/auth.py
@@ -27,39 +27,48 @@ def get_signing_key(jwt_token: str):
     return jwks_client.get_signing_key_from_jwt(jwt_token).key
 
 
-def authorize_user(token: Union[str, None]) -> UserInfo:
+def authorize_user(
+    authorization: Union[str, None], user_info: Union[str, None]
+) -> UserInfo:
     if not environment.get("JWT_AUTH"):
         logger.warning("JWT_AUTH is turned off.")
         return UserInfo(
             user_id="1234-1234-1234-1234", first_name="Test", last_name="User"
         )
-    if token is None:
-        raise AuthError("Unauthorized. No token was provided")
+    if authorization is None:
+        raise AuthError("Unauthorized. No authorization token was provided")
+    if user_info is None:
+        raise AuthError("Unauthorized. No user info token was provided")
     try:
-        signing_key = get_signing_key(token)
-        decoded_jwt = jwt.decode(
-            token,
+        signing_key = get_signing_key(authorization)
+        decoded_authorization = jwt.decode(
+            authorization,
             signing_key,
             algorithms=["RS256", "RS512"],
             audience=get_jwks_aud(),
             options={
-                "require": [
-                    "aud",
-                    "sub",
-                    "accreditation/role",
-                    "user/uuid",
-                    "user/firstName",
-                    "user/lastName",
-                ]
+                "require": ["aud", "sub", "accreditation/role", "user/uuid"]
             },
         )
-        role = decoded_jwt.get("accreditation/role")
+        role = decoded_authorization.get("accreditation/role")
         if role != "role/dataadministrator":
             raise AuthError(f"Can't start job with role: {role}")
-
-        user_id = decoded_jwt.get("user/uuid")
-        first_name = decoded_jwt.get("user/firstName")
-        last_name = decoded_jwt.get("user/lastName")
+        decoded_user_info = jwt.decode(
+            user_info,
+            signing_key,
+            algorithms=["RS256", "RS512"],
+            options={
+                "require": ["user/uuid", "user/firstName", "user/lastName"],
+                "verify_aud": False,
+            },
+        )
+        if decoded_authorization.get("user/uuid") != decoded_user_info.get(
+            "user/uuid"
+        ):
+            raise AuthError("Token mismatch")
+        user_id = decoded_user_info.get("user/uuid")
+        first_name = decoded_user_info.get("user/firstName")
+        last_name = decoded_user_info.get("user/lastName")
         return UserInfo(
             user_id=str(user_id),
             first_name=str(first_name),

--- a/job_service/api/job_api.py
+++ b/job_service/api/job_api.py
@@ -29,7 +29,9 @@ def get_jobs(query: GetJobRequest):
 @validate()
 def new_job(body: NewJobsRequest):
     logger.info(f"POST /jobs with request body: {body}")
-    user_info = auth.authorize_user(request.cookies.get("authorization"))
+    user_info = auth.authorize_user(
+        request.cookies.get("authorization"), request.cookies.get("user-info")
+    )
     response_list = []
     for job_request in body.jobs:
         try:

--- a/tests/resources/test_data.py
+++ b/tests/resources/test_data.py
@@ -1,63 +1,62 @@
 from datetime import datetime, timedelta
 
 
-valid_jwt_payload = {
-    'aud': ['no.ssb.fdb', 'datastore'],
-    'exp': (datetime.now() + timedelta(hours=1)).timestamp(),
-    'accreditation/role': 'role/dataadministrator',
-    'sub': 'testuser',
+valid_authorization_payload = {
+    "aud": ["no.ssb.fdb", "datastore"],
+    "exp": (datetime.now() + timedelta(hours=1)).timestamp(),
+    "accreditation/role": "role/dataadministrator",
+    "sub": "testuser",
+    "user/uuid": "1234-1234-1234-1234",
+}
+
+authorization_payload_no_user_id = {
+    "aud": ["no.ssb.fdb", "datastore"],
+    "exp": (datetime.now() + timedelta(hours=1)).timestamp(),
+    "accreditation/role": "role/dataadministrator",
+    "sub": "testuser",
+}
+
+authorization_payload_wrong_accreditation = {
+    "aud": ["no.ssb.fdb", "datastore"],
+    "exp": (datetime.now() + timedelta(hours=1)).timestamp(),
+    "accreditation/role": "role/researcher",
+    "sub": "testuser",
+    "user/uuid": "1234-1234-1234-1234",
+}
+
+authorization_payload_expired = {
+    "aud": ["no.ssb.fdb", "datastore"],
+    "exp": (datetime.now() - timedelta(hours=1)).timestamp(),
+    "accreditation/role": "role/dataadministrator",
+    "sub": "testuser",
+    "user/uuid": "1234-1234-1234-1234",
+}
+
+valid_user_info_payload = {
+    "aud": ["rose"],
+    "exp": (datetime.now() + timedelta(hours=1)).timestamp(),
+    "accreditation/role": "role/dataadministrator",
+    "sub": "testuser",
     "user/uuid": "1234-1234-1234-1234",
     "user/firstName": "Test",
-    "user/lastName": "Brukersen"
+    "user/lastName": "Brukersen",
 }
 
-
-jwt_payload_no_user_id = {
-    'aud': ['no.ssb.fdb', 'datastore'],
-    'exp': (datetime.now() + timedelta(hours=1)).timestamp(),
-    'accreditation/role': 'role/dataadministrator',
-    'sub': 'testuser',
-    "user/firstName": "Test",
-    "user/lastName": "Brukersen"
-}
-
-jwt_payload_no_first_name = {
-    'aud': ['no.ssb.fdb', 'datastore'],
-    'exp': (datetime.now() + timedelta(hours=1)).timestamp(),
-    'accreditation/role': 'role/dataadministrator',
-    'sub': 'testuser',
+user_info_payload_no_first_name = {
+    "aud": ["rose"],
+    "exp": (datetime.now() + timedelta(hours=1)).timestamp(),
+    "accreditation/role": "role/dataadministrator",
+    "sub": "testuser",
     "user/uuid": "1234-1234-1234-1234",
-    "user/lastName": "Brukersen"
+    "user/lastName": "Brukersen",
 }
 
 
-jwt_payload_no_last_name = {
-    'aud': ['no.ssb.fdb', 'datastore'],
-    'exp': (datetime.now() + timedelta(hours=1)).timestamp(),
-    'accreditation/role': 'role/dataadministrator',
-    'sub': 'testuser',
-    "user/uuid": "1234-1234-1234-1234",
-    "user/firstName": "Test"
-}
-
-
-jwt_payload_wrong_accreditation = {
-    'aud': ['no.ssb.fdb', 'datastore'],
-    'exp': (datetime.now() + timedelta(hours=1)).timestamp(),
-    'accreditation/role': 'role/researcher',
-    'sub': 'testuser',
+user_info_payload_no_last_name = {
+    "aud": ["rose"],
+    "exp": (datetime.now() + timedelta(hours=1)).timestamp(),
+    "accreditation/role": "role/dataadministrator",
+    "sub": "testuser",
     "user/uuid": "1234-1234-1234-1234",
     "user/firstName": "Test",
-    "user/lastName": "Brukersen"
-}
-
-
-jwt_payload_expired = {
-    'aud': ['no.ssb.fdb', 'datastore'],
-    'exp': (datetime.now() - timedelta(hours=1)).timestamp(),
-    'accreditation/role': 'role/dataadministrator',
-    'sub': 'testuser',
-    "user/uuid": "1234-1234-1234-1234",
-    "user/firstName": "Test",
-    "user/lastName": "Brukersen"
 }


### PR DESCRIPTION
There is no userinfo in the authorization token, so we need to use the user-info cookie header to get user information for the job database