### PR TITLE
New endpoints and functionality for start/stop receiving new jobs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,34 @@ _____
 >
 ></details>
 _____
+> ### **[POST]** `/prepare-for-upgrade`
+>Sets a flagg that prevents receiving new jobs.
+>This will typically be the case when new versions of containers are about to be deployed.
+><details>
+>  <summary>Responses</summary>
+>
+>  | status | json                                                                                        |
+>  |--------|---------------------------------------------------------------------------------------------|
+>  |   200  |```{"status": "SUCCESS", "msg": "PREPARE_FOR_UPGRADE"}``` |
+>  |   400  |```{"message": "<Error message>"}```                                                         |
+>  |   500  |```{"message": "<Error message>"}```                                                         |
+>
+></details>
+_____
+> ### **[POST]** `/upgrade-done`
+>Unsets a flagg that prevents receiving new jobs.
+>This will typically be the case when deploy is done and job service will start receiving new jobs.
+><details>
+>  <summary>Responses</summary>
+>
+>  | status | json                                                                                        |
+>  |--------|---------------------------------------------------------------------------------------------|
+>  |   200  |```{"status": "SUCCESS", "msg": "UPGRADE_DONE"}``` |
+>  |   400  |```{"message": "<Error message>"}```                                                         |
+>  |   500  |```{"message": "<Error message>"}```                                                         |
+>
+></details>
+_____
 </br>
 </br>
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,8 @@ Add Python Interpreter "Poetry Environment".
 
 
 ### Running unit tests
-Open terminal and go to root directory of the project and run:
+Start Docker Desktop if you are on Mac.
+Open terminal, go to root directory of the project and run:
 ````
 poetry run pytest --cov=job_service/
 ````

--- a/job_service/adapter/maintenance_db.py
+++ b/job_service/adapter/maintenance_db.py
@@ -1,0 +1,45 @@
+import logging
+
+import pymongo
+
+from job_service.config import environment, secrets
+from job_service.exceptions import NotFoundException
+
+MONGODB_URL = environment.get("MONGODB_URL")
+MONGODB_USER = secrets.get("MONGODB_USER")
+MONGODB_PASSWORD = secrets.get("MONGODB_PASSWORD")
+
+client = pymongo.MongoClient(
+    MONGODB_URL,
+    username=MONGODB_USER,
+    password=MONGODB_PASSWORD,
+    authSource="admin",
+)
+db = client.jobDB
+maintenance = db.maintenance
+
+logger = logging.getLogger()
+
+
+def set_upgrade_in_progress(flag: bool):
+    try:
+        maintenance.update_one(
+            {"id": "upgrade_in_progress"},
+            {"$set":
+                {
+                    "flag": flag
+                }
+            },
+            upsert=True,
+        )
+    except Exception as e:
+        logger.error(f"Exception occured while updating upgrade_in_progress with value: {flag}")
+        raise e
+    logger.info(f"Successfully updated upgrade_in_progress with value: {flag}")
+
+
+def is_upgrade_in_progress() -> bool:
+    result = maintenance.find_one({"id": "upgrade_in_progress"})
+    if not result:
+        raise NotFoundException(f"No upgrade_in_progress found in collection jobDB.maintenance")
+    return result['flag']

--- a/job_service/api/maintenance_api.py
+++ b/job_service/api/maintenance_api.py
@@ -1,0 +1,23 @@
+import logging
+
+from flask import Blueprint, jsonify
+
+from job_service.adapter import maintenance_db
+
+logger = logging.getLogger()
+
+maintenance_api = Blueprint("maintenance_api", __name__)
+
+
+@maintenance_api.route("/prepare-for-upgrade", methods=["POST"])
+def prepare_for_upgrade():
+    maintenance_db.set_upgrade_in_progress(True)
+    logger.info(f"POST /prepare-for-upgrade has set upgrade status = True")
+    return jsonify({"status": "SUCCESS", "msg": "PREPARE_FOR_UPGRADE"}), 200
+
+
+@maintenance_api.route("/upgrade-done", methods=["POST"])
+def upgrade_done():
+    maintenance_db.set_upgrade_in_progress(False)
+    logger.info(f"POST /upgrade-done has set upgrade status = False")
+    return jsonify({"status": "SUCCESS", "msg": "UPGRADE_DONE"}), 200

--- a/job_service/app.py
+++ b/job_service/app.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 from job_service.api.job_api import job_api
 from job_service.api.targets_api import targets_api
 from job_service.api.importable_datasets_api import importable_datasets_api
+from job_service.api.maintenance_api import maintenance_api
 from job_service.exceptions import (
     AuthError,
     JobExistsException,
@@ -42,6 +43,7 @@ app = Flask(__name__)
 app.register_blueprint(job_api)
 app.register_blueprint(importable_datasets_api)
 app.register_blueprint(targets_api)
+app.register_blueprint(maintenance_api)
 
 init_json_logging()
 

--- a/tests/unit/adapter/test_maintenance_db.py
+++ b/tests/unit/adapter/test_maintenance_db.py
@@ -1,0 +1,36 @@
+# pylint: disable=unused-argument
+from pytest_mock import MockFixture
+from testcontainers.mongodb import MongoDbContainer
+
+from job_service.adapter import maintenance_db
+
+DOCUMENT_DICT = {
+    "id": "upgrade_in_progress",
+    "flag": False
+}
+
+mongo = MongoDbContainer("mongo:5.0")
+mongo.start()
+DB_CLIENT = mongo.get_connection_client()
+
+
+def teardown_module():
+    mongo.stop()
+
+
+def setup_function():
+    DB_CLIENT.jobdb.drop_collection("maintenance")
+
+
+def test_set_upgrade_in_progress(mocker: MockFixture):
+    mocker.patch.object(
+        maintenance_db, "maintenance", DB_CLIENT.jobdb.maintenance
+    )
+
+    maintenance_db.set_upgrade_in_progress(True)
+    assert DB_CLIENT.jobdb.maintenance.count_documents({}) == 1
+    assert maintenance_db.is_upgrade_in_progress() == True
+
+    maintenance_db.set_upgrade_in_progress(False)
+    assert DB_CLIENT.jobdb.maintenance.count_documents({}) == 1
+    assert maintenance_db.is_upgrade_in_progress() == False

--- a/tests/unit/api/test_maintenance_api.py
+++ b/tests/unit/api/test_maintenance_api.py
@@ -1,0 +1,22 @@
+from flask import url_for
+from pytest_mock import MockFixture
+
+from job_service.adapter import maintenance_db
+
+
+def test_prepare_for_upgrade(flask_app, mocker: MockFixture):
+    set_upgrade_in_progress = mocker.patch.object(maintenance_db, "set_upgrade_in_progress")
+    response = flask_app.post(url_for("maintenance_api.prepare_for_upgrade"))
+
+    set_upgrade_in_progress.assert_called_once()
+    assert response.status_code == 200
+    assert response.json == {"status": "SUCCESS", "msg": "PREPARE_FOR_UPGRADE"}
+
+
+def test_upgrade_done(flask_app, mocker: MockFixture):
+    set_upgrade_in_progress = mocker.patch.object(maintenance_db, "set_upgrade_in_progress")
+    response = flask_app.post(url_for("maintenance_api.upgrade_done"))
+
+    set_upgrade_in_progress.assert_called_once()
+    assert response.status_code == 200
+    assert response.json == {"status": "SUCCESS", "msg": "UPGRADE_DONE"}


### PR DESCRIPTION
2 new endpoints:

- /prepare-for-upgrade
This endpoint will set a flagg in MongoDB to True and force job_api to reject any new jobs.
 
- /upgrade-done
This endpoint sets the flagg back to False and job_api will start accepting new jobs as usual.