### PR TITLE
Bugfix get maintenance status

### DIFF
--- a/job_service/adapter/maintenance_db.py
+++ b/job_service/adapter/maintenance_db.py
@@ -37,13 +37,15 @@ def set_status(status_request: MaintenanceStatusRequest):
         )
         raise e
 
+
 def get_latest_status():
     cursor = (
         maintenance.find({}, {"_id": 0}).sort([("timestamp", -1)]).limit(1)
     )
     documents = list(cursor)
     if len(documents) == 0:
-        return initialize()
+        initialize()
+        return get_latest_status()
     return documents[0]
 
 
@@ -51,12 +53,14 @@ def get_history():
     cursor = maintenance.find({}, {"_id": 0}).sort([("timestamp", -1)])
     documents = list(cursor)
     if len(documents) == 0:
-        return [initialize()]
+        initialize()
+        return get_history()
     return documents
+
 
 def initialize():
     logger.info("initializing")
-    return set_status(
+    set_status(
         MaintenanceStatusRequest(
             msg="Initial status inserted by job service at startup.",
             paused=False,

--- a/job_service/api/maintenance_api.py
+++ b/job_service/api/maintenance_api.py
@@ -15,13 +15,8 @@ maintenance_api = Blueprint("maintenance_api", __name__)
 @validate()
 def set_status(body: MaintenanceStatusRequest):
     logger.info(f"POST /maintenance-status with request body: {body}")
-    maintenance_db.set_status(body)
-    response = {
-        "status": "SUCCESS",
-        "msg": body.dict()["msg"],
-        "paused": body.dict()["paused"],
-    }
-    return jsonify(response), 200
+    new_status = maintenance_db.set_status(body)
+    return jsonify(new_status), 200
 
 
 @maintenance_api.route("/maintenance-status", methods=["GET"])

--- a/tests/unit/adapter/test_maintenance_db.py
+++ b/tests/unit/adapter/test_maintenance_db.py
@@ -15,12 +15,12 @@ def teardown_module():
 
 
 def setup_function():
-    DB_CLIENT.maintenance_db.drop_collection("maintenance")
+    DB_CLIENT.jobdb.drop_collection("maintenance")
 
 
 def test_initialize_after_get_latest_status(mocker: MockFixture):
     mocker.patch.object(
-        maintenance_db, "maintenance", DB_CLIENT.maintenance_db.maintenance
+        maintenance_db, "maintenance", DB_CLIENT.jobdb.maintenance
     )
     latest_status = maintenance_db.get_latest_status()
 
@@ -34,7 +34,7 @@ def test_initialize_after_get_latest_status(mocker: MockFixture):
 
 def test_initialize_after_get_history(mocker: MockFixture):
     mocker.patch.object(
-        maintenance_db, "maintenance", DB_CLIENT.maintenance_db.maintenance
+        maintenance_db, "maintenance", DB_CLIENT.jobdb.maintenance
     )
     statuses = maintenance_db.get_history()
 
@@ -48,7 +48,7 @@ def test_initialize_after_get_history(mocker: MockFixture):
 
 def test_set_status(mocker: MockFixture):
     mocker.patch.object(
-        maintenance_db, "maintenance", DB_CLIENT.maintenance_db.maintenance
+        maintenance_db, "maintenance", DB_CLIENT.jobdb.maintenance
     )
 
     status = maintenance_db.set_status(
@@ -62,21 +62,21 @@ def test_set_status(mocker: MockFixture):
 
 def test_set_and_get_status(mocker: MockFixture):
     mocker.patch.object(
-        maintenance_db, "maintenance", DB_CLIENT.maintenance_db.maintenance
+        maintenance_db, "maintenance", DB_CLIENT.jobdb.maintenance
     )
 
     maintenance_db.set_status(
         MaintenanceStatusRequest(msg="we upgrade chill", paused=True)
     )
-    assert DB_CLIENT.maintenance_db.maintenance.count_documents({}) == 1
+    assert DB_CLIENT.jobdb.maintenance.count_documents({}) == 1
     maintenance_db.set_status(
         MaintenanceStatusRequest(msg="finished upgrading", paused=False)
     )
-    assert DB_CLIENT.maintenance_db.maintenance.count_documents({}) == 2
+    assert DB_CLIENT.jobdb.maintenance.count_documents({}) == 2
     maintenance_db.set_status(
         MaintenanceStatusRequest(msg="we need to upgrade again", paused=True)
     )
-    assert DB_CLIENT.maintenance_db.maintenance.count_documents({}) == 3
+    assert DB_CLIENT.jobdb.maintenance.count_documents({}) == 3
 
     latest_status = maintenance_db.get_latest_status()
 
@@ -87,7 +87,7 @@ def test_set_and_get_status(mocker: MockFixture):
 
 def test_get_history(mocker: MockFixture):
     mocker.patch.object(
-        maintenance_db, "maintenance", DB_CLIENT.maintenance_db.maintenance
+        maintenance_db, "maintenance", DB_CLIENT.jobdb.maintenance
     )
 
     maintenance_db.set_status(

--- a/tests/unit/adapter/test_maintenance_db.py
+++ b/tests/unit/adapter/test_maintenance_db.py
@@ -24,7 +24,9 @@ def test_initialize_after_get_latest_status(mocker: MockFixture):
     )
     document = maintenance_db.get_latest_status()
 
-    assert document["msg"] == "Initial status inserted by job service at startup."
+    assert (
+        document["msg"] == "Initial status inserted by job service at startup."
+    )
     assert document["paused"] == 0
     assert "timestamp" in document.keys()
 
@@ -35,7 +37,10 @@ def test_initialize_after_get_history(mocker: MockFixture):
     )
     documents = maintenance_db.get_history()
 
-    assert documents[0]["msg"] == "Initial status inserted by job service at startup."
+    assert (
+        documents[0]["msg"]
+        == "Initial status inserted by job service at startup."
+    )
     assert documents[0]["paused"] == 0
     assert "timestamp" in documents[0].keys()
 
@@ -75,11 +80,12 @@ def test_get_history(mocker: MockFixture):
     maintenance_db.set_status(
         MaintenanceStatusRequest(msg="second", paused=False)
     )
-    maintenance_db.set_status(MaintenanceStatusRequest(msg="last", paused=True))
+    maintenance_db.set_status(
+        MaintenanceStatusRequest(msg="last", paused=True)
+    )
 
     documents = maintenance_db.get_history()
 
     assert documents[0]["msg"] == "last"
     assert documents[1]["msg"] == "second"
     assert documents[2]["msg"] == "first"
-

--- a/tests/unit/api/test_maintenance_api.py
+++ b/tests/unit/api/test_maintenance_api.py
@@ -87,7 +87,9 @@ def test_get_maintenance_status(flask_app, mocker: MockFixture):
     assert response.json == RESPONSE_FROM_DB[0]
 
 
-def test_get_maintenance_status_from_empty_collection(flask_app, mocker: MockFixture):
+def test_get_maintenance_status_from_empty_collection(
+    flask_app, mocker: MockFixture
+):
     get_status = mocker.patch.object(
         maintenance_db, "get_latest_status", return_value={}
     )
@@ -110,7 +112,9 @@ def test_get_maintenance_history(flask_app, mocker: MockFixture):
     assert response.json == RESPONSE_FROM_DB
 
 
-def test_get_maintenance_history_from_empty_collection(flask_app, mocker: MockFixture):
+def test_get_maintenance_history_from_empty_collection(
+    flask_app, mocker: MockFixture
+):
     get_history = mocker.patch.object(
         maintenance_db, "get_history", return_value=[]
     )

--- a/tests/unit/api/test_maintenance_api.py
+++ b/tests/unit/api/test_maintenance_api.py
@@ -10,21 +10,24 @@ MAINTENANCE_STATUS_REQUEST_INVALID_PAUSE_VALUE = {
     "paused": "Should not be a string",
 }
 
+NEW_STATUS = {
+    "msg": "we upgrade chill",
+    "paused": 1,
+    "timestamp": "2023-08-31 16:26:27.575276",
+}
+
 RESPONSE_FROM_DB = [
     {
-        "_id": "64ee001303a2f9d32f549e0d",
         "msg": "Today is 2023-08-31, we need to upgrade again",
         "paused": 1,
         "timestamp": "2023-08-31 16:26:27.575276",
     },
     {
-        "_id": "64ee001303a2f9d32f549e0d",
         "msg": "Today is 2023-08-30, finished upgrading",
         "paused": 0,
         "timestamp": "2023-08-30 16:26:27.575276",
     },
     {
-        "_id": "64ee001303a2f9d32f549e0d",
         "msg": "Today is 2023-08-29, we need to upgrade",
         "paused": 1,
         "timestamp": "2023-08-29 16:26:27.575276",
@@ -33,7 +36,9 @@ RESPONSE_FROM_DB = [
 
 
 def test_set_maintenance_status(flask_app, mocker: MockFixture):
-    db_set_status = mocker.patch.object(maintenance_db, "set_status")
+    db_set_status = mocker.patch.object(
+        maintenance_db, "set_status", return_value=NEW_STATUS
+    )
     response = flask_app.post(
         url_for("maintenance_api.set_status"),
         json=MAINTENANCE_STATUS_REQUEST_VALID,
@@ -41,12 +46,7 @@ def test_set_maintenance_status(flask_app, mocker: MockFixture):
 
     db_set_status.assert_called_once()
     assert response.status_code == 200
-
-    assert response.json == {
-        "status": "SUCCESS",
-        "msg": "we upgrade chill",
-        "paused": 1,
-    }
+    assert response.json == NEW_STATUS
 
 
 def test_set_maintenance_status_with_no_msg(flask_app, mocker: MockFixture):

--- a/tests/unit/model/test_job.py
+++ b/tests/unit/model/test_job.py
@@ -5,17 +5,17 @@ import pytest
 from job_service.model.job import Job
 
 
-RESOURCE_DIR = 'tests/resources/model'
-with open(f'{RESOURCE_DIR}/valid_jobs.json', encoding='utf-8') as f:
+RESOURCE_DIR = "tests/resources/model"
+with open(f"{RESOURCE_DIR}/valid_jobs.json", encoding="utf-8") as f:
     VALID_JOBS = json.load(f)
-with open(f'{RESOURCE_DIR}/invalid_jobs.json', encoding='utf-8') as f:
+with open(f"{RESOURCE_DIR}/invalid_jobs.json", encoding="utf-8") as f:
     INVALID_JOBS = json.load(f)
 
 
 def test_valid_jobs():
     for job_dict in VALID_JOBS:
         job = Job(**job_dict)
-        assert job.dict(by_alias=True) == {'log': [], **job_dict}
+        assert job.dict(by_alias=True) == {"log": [], **job_dict}
 
 
 def test_invalid_jobs():

--- a/tests/unit/model/test_request.py
+++ b/tests/unit/model/test_request.py
@@ -7,18 +7,18 @@ from job_service.model.job import Job, UserInfo
 from job_service.model.request import NewJobsRequest, NewJobRequest
 
 
-RESOURCE_DIR = 'tests/resources/model'
-VALID_JOB_REQUESTS_PATH = f'{RESOURCE_DIR}/valid_job_requests.json'
-with open(VALID_JOB_REQUESTS_PATH, 'r', encoding='utf-8') as f:
+RESOURCE_DIR = "tests/resources/model"
+VALID_JOB_REQUESTS_PATH = f"{RESOURCE_DIR}/valid_job_requests.json"
+with open(VALID_JOB_REQUESTS_PATH, "r", encoding="utf-8") as f:
     VALID_JOB_REQUESTS = json.load(f)
-INVALID_JOB_REQUESTS_PATH = f'{RESOURCE_DIR}/invalid_job_requests.json'
-with open(INVALID_JOB_REQUESTS_PATH, 'r', encoding='utf-8') as f:
+INVALID_JOB_REQUESTS_PATH = f"{RESOURCE_DIR}/invalid_job_requests.json"
+with open(INVALID_JOB_REQUESTS_PATH, "r", encoding="utf-8") as f:
     INVALID_JOB_REQUESTS = json.load(f)
-JOB_ID = '123-123-123-123'
+JOB_ID = "123-123-123-123"
 USER_INFO_DICT = {
-    'userId': '123-123-123',
-    'firstName': 'Data',
-    'lastName': 'Admin'
+    "userId": "123-123-123",
+    "firstName": "Data",
+    "lastName": "Admin",
 }
 USER_INFO = UserInfo(**USER_INFO_DICT)
 
@@ -34,6 +34,6 @@ def test_new_jobs_requests():
 
 
 def test_invalid_new_jobs_requests():
-    for job in INVALID_JOB_REQUESTS['jobs']:
+    for job in INVALID_JOB_REQUESTS["jobs"]:
         with pytest.raises(ValidationError):
             NewJobRequest(**job)


### PR DESCRIPTION
I got Internal server error on first request to GET /maintenance-status. This PR fixes the issue by returning the same object also when `initialize` method runs.