### PR TITLE
Bugfix tarfile error

### DIFF
--- a/job_service/app.py
+++ b/job_service/app.py
@@ -10,7 +10,6 @@ from job_service.api.job_api import job_api
 from job_service.api.targets_api import targets_api
 from job_service.api.importable_datasets_api import importable_datasets_api
 from job_service.api.maintenance_api import maintenance_api
-from job_service.adapter import maintenance_db
 from job_service.exceptions import (
     AuthError,
     JobExistsException,


### PR DESCRIPTION
# BUGFIX tarfile error

Simple fix that handles "corrupt" tarfiles by skipping them and logging a warning.
This will mostly happen when the file moving job is currently working on moving a larger file to the input directory.
We could give the user information that the dataset is currently being transferred, but as the file moving job itself can take X amount of minutes, I think we are better off just waiting for the full transfer to be done, and ignoring it until then.