### PR TITLE
MICNO-26: Bugfixing after complete system-test and code-cleanup

### DIFF
--- a/job_service/adapter/job_db.py
+++ b/job_service/adapter/job_db.py
@@ -1,6 +1,6 @@
 from typing import List
 import uuid
-from datetime import datetime
+from datetime import datetime, UTC
 import logging
 import pymongo
 from pymongo.results import UpdateResult
@@ -114,7 +114,7 @@ def update_job(job_id: str, body: UpdateJobRequest) -> Job:
     Updates job with supplied job_id with new status.
     Appends additional log if supplied.
     """
-    now = datetime.now()
+    now = datetime.now(UTC).replace(tzinfo=None)
     find_query = {"jobId": job_id}
     job: Job = in_progress.find_one(find_query)
     if job is None:

--- a/job_service/model/request.py
+++ b/job_service/model/request.py
@@ -14,7 +14,7 @@ from job_service.model.job import (
 )
 
 
-class NewJobRequest(CamelModel, extra="forbid"):
+class NewJobRequest(CamelModel, extra="forbid", use_enum_values=True):
     operation: Operation
     target: str
     release_status: Optional[ReleaseStatus] = None


### PR DESCRIPTION
Fixing bugs encountered when running a complete system test (integration-test).
(model-validator code is removed because it was never used. self.Log could never be None, only an empty list as defined in the Job-class.)
